### PR TITLE
Fixed null exception on Get Certification ID button when cookie data is null

### DIFF
--- a/app/search/certid.js
+++ b/app/search/certid.js
@@ -134,7 +134,7 @@ var chplCertIdWidget = (function(){
 			}
 
 			if (null !== year) {
-				$("#btnEhrGetCertificationId").text("Get " + data.year + " EHR Certification ID");
+				$("#btnEhrGetCertificationId").text("Get " + year + " EHR Certification ID");
 			} else {
 				$("#btnEhrGetCertificationId").text("Get EHR Certification ID");
 			}


### PR DESCRIPTION
Fixed null exception on Get Certification ID button when cookie data is null