### PR TITLE
OCD-4307 

### DIFF
--- a/src/app/components/action-bar/action-bar-messages.jsx
+++ b/src/app/components/action-bar/action-bar-messages.jsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles({
     borderRadius: '4px',
     boxShadow: 'rgb(149 157 165 / 30%) -8px 0px 16px 0px',
     width: '250px',
+    zIndex: 1298,
   },
   toggle: {
     width: '32px',


### PR DESCRIPTION
This pull request introduces a minor style adjustment to the `action-bar-messages` component. The change sets a specific `zIndex` value to ensure the component displays correctly above other elements when necessary.

* Style update:
  * Added `zIndex: 1298` to the `root` style in `action-bar-messages.jsx` to control stacking order.[#OCD-4307-FixDrawer]