### PR TITLE
OCD-4307 Fix

### DIFF
--- a/src/app/components/login/toggle.jsx
+++ b/src/app/components/login/toggle.jsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles({
     },
   },
   loginCard: {
-    width: '300px!important',
+    width: '300px !important',
     [theme.breakpoints.up('md')]: {
       width: '375px',
     },

--- a/src/app/components/login/toggle.jsx
+++ b/src/app/components/login/toggle.jsx
@@ -129,7 +129,8 @@ function ChplToggle({ dispatch = () => {} }) {
     <>
       <Button
         id="login-toggle"
-        aria-describedby="admin-login-form"
+        aria-controls={!isMobile && loginPopoverOpen ? 'admin-login-form' : undefined}
+        aria-haspopup="dialog"
         aria-expanded={isToggleOpen ? 'true' : undefined}
         onClick={handleClick}
         className={classes.whiteButton}

--- a/src/app/components/login/toggle.jsx
+++ b/src/app/components/login/toggle.jsx
@@ -27,8 +27,15 @@ const useStyles = makeStyles({
   popoverSpacing: {
     marginLeft: '8px',
   },
+  '@global': {
+    '#admin-login-paper.MuiPaper-root.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded': {
+      width: '300px !important',
+      maxWidth: '300px !important',
+      right: 'auto !important',
+    },
+  },
   loginCard: {
-    width: '300px',
+    width: '300px!important',
     [theme.breakpoints.up('md')]: {
       width: '375px',
     },
@@ -144,6 +151,9 @@ function ChplToggle({ dispatch = () => {} }) {
         }}
         className={classes.popoverSpacing}
         disableScrollLock
+        PaperProps={{
+          id: 'admin-login-paper',
+        }}
       >
         { loginWidgetState === 'LOGGEDIN' ? (
           <ChplAdminMenu onClose={handleClose} />

--- a/src/app/navigation/desktop-nav.jsx
+++ b/src/app/navigation/desktop-nav.jsx
@@ -140,11 +140,33 @@ function ChplDesktopNav({
   }, [$rootScope]);
 
   const toggleCmsWidget = () => {
-    setCmsAnchorEl(cmsAnchorEl ? null : cmsButtonRef.current);
+    if (cmsAnchorEl) {
+      setCmsAnchorEl(null);
+      return;
+    }
+    setCompareAnchorEl(null);
+    setResourcesOpen(false);
+    setShortcutsOpen(false);
+    setCmsAnchorEl(cmsButtonRef.current);
+  };
+
+  const closeCmsWidget = () => {
+    setCmsAnchorEl(null);
   };
 
   const toggleCompareWidget = () => {
-    setCompareAnchorEl(compareAnchorEl ? null : compareButtonRef.current);
+    if (compareAnchorEl) {
+      setCompareAnchorEl(null);
+      return;
+    }
+    setCmsAnchorEl(null);
+    setResourcesOpen(false);
+    setShortcutsOpen(false);
+    setCompareAnchorEl(compareButtonRef.current);
+  };
+
+  const closeCompareWidget = () => {
+    setCompareAnchorEl(null);
   };
 
 
@@ -205,15 +227,18 @@ function ChplDesktopNav({
       <Menu
         anchorEl={cmsAnchorEl}
         open={!!cmsAnchorEl}
-        onClose={toggleCmsWidget}
+        onClose={closeCmsWidget}
         getContentAnchorEl={null}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         disableScrollLock
+        hideBackdrop
+        style={{ pointerEvents: 'none' }}
         PaperProps={{
           className: classes.menuPaper,
           style: {
             width: '400px',
+            pointerEvents: 'auto',
           },
         }}
       >
@@ -231,15 +256,18 @@ function ChplDesktopNav({
       <Menu
         anchorEl={compareAnchorEl}
         open={!!compareAnchorEl}
-        onClose={toggleCompareWidget}
+        onClose={closeCompareWidget}
         getContentAnchorEl={null}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         disableScrollLock
+        hideBackdrop
+        style={{ pointerEvents: 'none' }}
         PaperProps={{
           className: classes.menuPaper,
           style: {
             width: '400px',
+            pointerEvents: 'auto',
           },
         }}
       >

--- a/src/app/navigation/desktop-nav.jsx
+++ b/src/app/navigation/desktop-nav.jsx
@@ -8,7 +8,7 @@ import {
   Box,
   Button,
   ClickAwayListener,
-  Menu,
+  Popover,
   makeStyles,
 } from '@material-ui/core';
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
@@ -112,21 +112,40 @@ function ChplDesktopNav({
 
   const classes = useStyles();
 
+  // These widgets can be opened by click handlers and root-scope broadcasts.
+  // When that happens during a render/layout transition, ref.current may not be a usable anchor.
+  // We only return anchors that are mounted and visible to avoid invalid anchorEl warnings.
+  const getVisibleAnchor = (ref) => {
+    const el = ref.current;
+    if (!el || !el.isConnected || el.offsetParent === null) {
+      return null;
+    }
+    return el;
+  };
+
   useEffect(() => {
     const deregisterShowCmsWidget = $rootScope.$on('ShowCmsWidget', () => {
+      const anchor = getVisibleAnchor(cmsButtonRef);
+      if (!anchor) {
+        return;
+      }
       setCompareAnchorEl(null);
       setResourcesOpen(false);
       setShortcutsOpen(false);
-      setCmsAnchorEl(cmsButtonRef.current);
+      setCmsAnchorEl(anchor);
     });
     const deregisterHideCmsWidget = $rootScope.$on('HideCmsWidget', () => {
       setCmsAnchorEl(null);
     });
     const deregisterShowCompareWidget = $rootScope.$on('ShowCompareWidget', () => {
-      setCmsAnchorEl(null);
+      const anchor = getVisibleAnchor(compareButtonRef);
+      if (!anchor) {
+        return;
+      }
+      setCmsAnchorEl(null); 
       setResourcesOpen(false);
       setShortcutsOpen(false);
-      setCompareAnchorEl(compareButtonRef.current);
+      setCompareAnchorEl(anchor);
     });
     const deregisterHideCompareWidget = $rootScope.$on('HideCompareWidget', () => {
       setCompareAnchorEl(null);
@@ -144,13 +163,18 @@ function ChplDesktopNav({
       setCmsAnchorEl(null);
       return;
     }
+    const anchor = getVisibleAnchor(cmsButtonRef);
+    if (!anchor) {
+      return;
+    }
     setCompareAnchorEl(null);
-    setResourcesOpen(false);
-    setShortcutsOpen(false);
-    setCmsAnchorEl(cmsButtonRef.current);
+    setCmsAnchorEl(anchor);
   };
 
-  const closeCmsWidget = () => {
+  const closeCmsWidget = (event, reason) => {
+    if (reason === 'backdropClick') {
+      return;
+    }
     setCmsAnchorEl(null);
   };
 
@@ -159,13 +183,20 @@ function ChplDesktopNav({
       setCompareAnchorEl(null);
       return;
     }
+
+    // Skip opening if the compare button is not currently a valid visible anchor.
+    const anchor = getVisibleAnchor(compareButtonRef);
+    if (!anchor) {
+      return;
+    }
     setCmsAnchorEl(null);
-    setResourcesOpen(false);
-    setShortcutsOpen(false);
-    setCompareAnchorEl(compareButtonRef.current);
+    setCompareAnchorEl(anchor);
   };
 
-  const closeCompareWidget = () => {
+  const closeCompareWidget = (event, reason) => {
+    if (reason === 'backdropClick') {
+      return;
+    }
     setCompareAnchorEl(null);
   };
 
@@ -224,11 +255,14 @@ function ChplDesktopNav({
       >
         CMS ID Creator
       </Button>
-      <Menu
+      {/*
+        Use Popover (not Menu) because this is a custom widget panel, not a menu list.
+        Menu tries to apply menu semantics/focus behavior that caused ref warnings with this content.
+      */}
+      <Popover
         anchorEl={cmsAnchorEl}
         open={!!cmsAnchorEl}
         onClose={closeCmsWidget}
-        getContentAnchorEl={null}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         disableScrollLock
@@ -243,7 +277,7 @@ function ChplDesktopNav({
         }}
       >
         <ChplCmsDisplay />
-      </Menu>
+      </Popover>
       <Button
         ref={compareButtonRef}
         onClick={toggleCompareWidget}
@@ -253,11 +287,10 @@ function ChplDesktopNav({
       >
         Compare Products
       </Button>
-      <Menu
+      <Popover
         anchorEl={compareAnchorEl}
         open={!!compareAnchorEl}
         onClose={closeCompareWidget}
-        getContentAnchorEl={null}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         disableScrollLock
@@ -272,7 +305,7 @@ function ChplDesktopNav({
         }}
       >
         <ChplCompareDisplay />
-      </Menu>
+      </Popover>
       <ClickAwayListener onClickAway={closeResources}>
         <Box className={classes.dropdownWrapper}>
           <Button


### PR DESCRIPTION
This pull request improves the accessibility, usability, and styling consistency of the login toggle and navigation menus in the application. The main changes focus on refining ARIA attributes for better accessibility, enhancing menu toggling logic to ensure only one menu is open at a time, and applying more precise styling to popovers and menus.

**Accessibility improvements:**

* Updated ARIA attributes on the login toggle `Button` to use `aria-controls`, `aria-haspopup="dialog"`, and `aria-expanded`, making the login popover more accessible to assistive technologies.

**Styling and layout enhancements:**

* Added a global style targeting the login popover (`#admin-login-paper`) to enforce a consistent width and prevent unwanted resizing, and updated the `loginCard` style to use `!important` for width.
* Passed a custom `id` (`admin-login-paper`) to the login popover's `PaperProps` for more precise styling.

**Navigation menu logic and behavior:**

* Refactored the CMS and Compare menu toggle logic in `ChplDesktopNav` to ensure that opening one menu closes the others, preventing multiple menus from being open simultaneously. Added dedicated close functions for each menu.
* Updated the `Menu` components for CMS and Compare to use the new close functions, hide the backdrop, and set `pointerEvents` styles to allow interaction only with the menu content. [[1]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL208-R241) [[2]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL234-R270)