### PR TITLE
OCD-4307 Nav Issue 

### DIFF
--- a/src/app/components/login/toggle.jsx
+++ b/src/app/components/login/toggle.jsx
@@ -29,13 +29,12 @@ const useStyles = makeStyles({
   },
   '@global': {
     '#admin-login-paper.MuiPaper-root.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded': {
-      width: '300px !important',
       maxWidth: '300px !important',
       right: 'auto !important',
     },
   },
   loginCard: {
-    width: '300px !important',
+    maxWidth: '300px !important',
     [theme.breakpoints.up('md')]: {
       width: '375px',
     },

--- a/src/app/navigation/desktop-nav.jsx
+++ b/src/app/navigation/desktop-nav.jsx
@@ -158,6 +158,13 @@ function ChplDesktopNav({
     };
   }, [$rootScope]);
 
+  const closeAllNavOverlays = () => {
+    setCmsAnchorEl(null);
+    setCompareAnchorEl(null);
+    setResourcesOpen(false);
+    setShortcutsOpen(false);
+  };
+
   const toggleCmsWidget = () => {
     if (cmsAnchorEl) {
       setCmsAnchorEl(null);
@@ -167,7 +174,7 @@ function ChplDesktopNav({
     if (!anchor) {
       return;
     }
-    setCompareAnchorEl(null);
+    closeAllNavOverlays();
     setCmsAnchorEl(anchor);
   };
 
@@ -189,7 +196,7 @@ function ChplDesktopNav({
     if (!anchor) {
       return;
     }
-    setCmsAnchorEl(null);
+    closeAllNavOverlays();
     setCompareAnchorEl(anchor);
   };
 
@@ -202,7 +209,13 @@ function ChplDesktopNav({
 
 
   const toggleResources = () => {
-    setResourcesOpen((prev) => !prev);
+    setResourcesOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        closeAllNavOverlays();
+      }
+      return next;
+    });
   };
 
   const closeResources = () => {
@@ -210,7 +223,13 @@ function ChplDesktopNav({
   };
 
   const toggleShortcuts = () => {
-    setShortcutsOpen((prev) => !prev);
+    setShortcutsOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        closeAllNavOverlays();
+      }
+      return next;
+    });
   };
 
   const closeShortcuts = () => {
@@ -236,13 +255,19 @@ function ChplDesktopNav({
   return (
     <Box className={classes.navContainer}>
       <Button
-        onClick={onHomeClick}
+        onClick={() => {
+          closeAllNavOverlays();
+          onHomeClick();
+        }}
         className={classes.whiteButton}
       >
         Home
       </Button>
       <Button
-        onClick={onSearchClick}
+        onClick={() => {
+          closeAllNavOverlays();
+          onSearchClick();
+        }}
         className={classes.whiteButton}
       >
         Search CHPL


### PR DESCRIPTION
This pull request improves the behavior and styling of navigation overlays and login components in the application. The main focus is to ensure that only one navigation overlay is open at a time, and to update the styling for better consistency across breakpoints.

Navigation overlay management improvements:

* Introduced a new `closeAllNavOverlays` function in `desktop-nav.jsx` to centralize the closing of all navigation overlays, ensuring only one overlay can be open at a time. This function is now called when toggling CMS, Compare, Resources, and Shortcuts overlays, as well as when clicking the Home and Search buttons. [[1]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aR161-R167) [[2]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL170-R177) [[3]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL192-R199) [[4]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL205-R232) [[5]](diffhunk://#diff-826d9620905b862827618638f5c842c7ce83ad9a0b35ad1ca786553d6b9bdc2aL239-R270)

Styling updates:

* Updated the `loginCard` and `#admin-login-paper` styles in `toggle.jsx` to use `maxWidth` instead of `width`, allowing for better responsiveness and consistency with Material UI practices.

[#OCD-4307FixAdminNav]