### PR TITLE
OCD-5335 Analytics for Admin Menu / Mobile Nav 

### DIFF
--- a/src/app/components/login/navigation/admin-menu-link-item.jsx
+++ b/src/app/components/login/navigation/admin-menu-link-item.jsx
@@ -42,7 +42,7 @@ function ChplAdminMenuLinkItem({
   const handleClick = () => {
     eventTrack({
       ...analytics,
-      event: `Go to ${text} Page`,
+      event: `Navigate to ${text} Page`,
       label: text,
       category: 'Navigation',
     });

--- a/src/app/components/login/navigation/admin-menu-link-item.jsx
+++ b/src/app/components/login/navigation/admin-menu-link-item.jsx
@@ -11,6 +11,8 @@ import {
 } from 'prop-types';
 
 import { ChplLink } from 'components/util';
+import { eventTrack } from 'services/analytics.service';
+import { useAnalyticsContext } from 'shared/contexts';
 import { palette } from 'themes';
 
 const useStyles = makeStyles({
@@ -35,9 +37,19 @@ function ChplAdminMenuLinkItem({
   text,
 }) {
   const classes = useStyles();
+  const { analytics } = useAnalyticsContext();
+
+  const handleClick = () => {
+    eventTrack({
+      ...analytics,
+      event: `Go to ${text} Page`,
+      category: 'Navigation',
+    });
+    onClose();
+  };
 
   return (
-    <ListItem className={classes.menuItem} onClick={onClose}>
+    <ListItem className={classes.menuItem} onClick={handleClick}>
       <ChplLink
         href={href}
         text={text}

--- a/src/app/components/login/navigation/admin-menu-link-item.jsx
+++ b/src/app/components/login/navigation/admin-menu-link-item.jsx
@@ -43,6 +43,7 @@ function ChplAdminMenuLinkItem({
     eventTrack({
       ...analytics,
       event: `Go to ${text} Page`,
+      label: text,
       category: 'Navigation',
     });
     onClose();

--- a/src/app/components/login/navigation/admin-menu-link-item.jsx
+++ b/src/app/components/login/navigation/admin-menu-link-item.jsx
@@ -42,8 +42,7 @@ function ChplAdminMenuLinkItem({
   const handleClick = () => {
     eventTrack({
       ...analytics,
-      event: `Navigate to ${text} Page`,
-      label: text,
+      event: `Go to ${text} Page`,
       category: 'Navigation',
     });
     onClose();

--- a/src/app/components/login/navigation/admin-menu-section.jsx
+++ b/src/app/components/login/navigation/admin-menu-section.jsx
@@ -58,6 +58,7 @@ function ChplAdminMenuSection({
     eventTrack({
       ...analytics,
       event: isOpen ? `Collapse ${title}` : `Expand ${title}`,
+      label: title,
       category: 'Navigation',
     });
     onToggle(section);

--- a/src/app/components/login/navigation/admin-menu-section.jsx
+++ b/src/app/components/login/navigation/admin-menu-section.jsx
@@ -16,6 +16,8 @@ import {
   string,
 } from 'prop-types';
 
+import { eventTrack } from 'services/analytics.service';
+import { useAnalyticsContext } from 'shared/contexts';
 import { palette } from 'themes';
 
 const useStyles = makeStyles({
@@ -50,12 +52,22 @@ function ChplAdminMenuSection({
   title,
 }) {
   const classes = useStyles();
+  const { analytics } = useAnalyticsContext();
+
+  const handleToggle = () => {
+    eventTrack({
+      ...analytics,
+      event: isOpen ? `Collapse ${title}` : `Expand ${title}`,
+      category: 'Navigation',
+    });
+    onToggle(section);
+  };
 
   return (
     <>
       <ListItem
         className={classes.sectionHeader}
-        onClick={() => onToggle(section)}
+        onClick={handleToggle}
         divider
       >
         <Typography className={classes.sectionHeaderText}>{title}</Typography>
@@ -64,7 +76,7 @@ function ChplAdminMenuSection({
           aria-label={isOpen ? `Collapse ${title}` : `Expand ${title}`}
           aria-expanded={isOpen}
           size="small"
-          onClick={(e) => { e.stopPropagation(); onToggle(section); }}
+          onClick={(e) => { e.stopPropagation(); handleToggle(); }}
         >
           {isOpen
             ? <ExpandLessIcon style={{color: 'black'}} />

--- a/src/app/components/login/navigation/admin-menu-section.jsx
+++ b/src/app/components/login/navigation/admin-menu-section.jsx
@@ -58,7 +58,6 @@ function ChplAdminMenuSection({
     eventTrack({
       ...analytics,
       event: isOpen ? `Collapse ${title}` : `Expand ${title}`,
-      label: title,
       category: 'Navigation',
     });
     onToggle(section);
@@ -80,7 +79,7 @@ function ChplAdminMenuSection({
           onClick={(e) => { e.stopPropagation(); handleToggle(); }}
         >
           {isOpen
-            ? <ExpandLessIcon style={{color: 'black'}} />
+            ? <ExpandLessIcon style={{ color: 'black' }} />
             : <ExpandMoreIcon color="primary" />}
         </IconButton>
       </ListItem>

--- a/src/app/navigation/mobile-nav-drawer.jsx
+++ b/src/app/navigation/mobile-nav-drawer.jsx
@@ -89,7 +89,7 @@ const useStyles = makeStyles({
 
 function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   const { hasAnyRole } = useContext(UserContext);
-  const analytics = useAnalyticsContext();
+  const { analytics } = useAnalyticsContext();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState({
     cms: false,
@@ -110,6 +110,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
     eventTrack({
       ...analytics,
       event: 'Go to Home Page',
+      label: 'Home',
       category: 'Navigation',
     });
     onHomeClick();
@@ -120,6 +121,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
     eventTrack({
       ...analytics,
       event: 'Go to Search Page',
+      label: 'Search CHPL',
       category: 'Navigation',
     });
     onSearchClick();
@@ -131,6 +133,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
     eventTrack({
       ...analytics,
       event: isCurrentlyOpen ? `Collapse ${title}` : `Expand ${title}`,
+      label: title,
       category: 'Navigation',
     });
     setExpandedSections((previous) => ({

--- a/src/app/navigation/mobile-nav-drawer.jsx
+++ b/src/app/navigation/mobile-nav-drawer.jsx
@@ -26,7 +26,8 @@ import {
 import ChplCmsDisplay from 'components/cms-widget/cms-display';
 import ChplCompareDisplay from 'components/compare-widget/compare-display';
 import { ChplLink } from 'components/util';
-import { UserContext } from 'shared/contexts';
+import { eventTrack } from 'services/analytics.service';
+import { UserContext, useAnalyticsContext } from 'shared/contexts';
 import { palette, theme } from 'themes';
 
 const useStyles = makeStyles({
@@ -88,6 +89,7 @@ const useStyles = makeStyles({
 
 function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   const { hasAnyRole } = useContext(UserContext);
+  const analytics = useAnalyticsContext();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState({
     cms: false,
@@ -105,21 +107,43 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   };
 
   const handleHomeClick = () => {
+    eventTrack({
+      ...analytics,
+      event: 'Go to Home Page',
+      category: 'Navigation',
+    });
     onHomeClick();
     closeMobileMenu();
   };
 
   const handleSearchClick = () => {
+    eventTrack({
+      ...analytics,
+      event: 'Go to Search Page',
+      category: 'Navigation',
+    });
     onSearchClick();
     closeMobileMenu();
   };
 
-  const toggleSection = (section) => {
+  const toggleSection = (section, title) => {
+    const isCurrentlyOpen = expandedSections[section];
+    eventTrack({
+      ...analytics,
+      event: isCurrentlyOpen ? `Collapse ${title}` : `Expand ${title}`,
+      category: 'Navigation',
+    });
     setExpandedSections((previous) => ({
       ...previous,
       [section]: !previous[section],
     }));
   };
+
+  const getItemAnalytics = (item) => ({
+    ...analytics,
+    event: item.analyticsEvent,
+    category: item.analyticsCategory ?? 'Navigation',
+  });
 
   const widgetSections = [{
     key: 'cms',
@@ -176,7 +200,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
           <Divider className={classes.drawerDivider} />
           {widgetSections.map((section) => (
             <React.Fragment key={section.key}>
-              <ListItem button onClick={() => toggleSection(section.key)} className={classes.drawerItem}>
+              <ListItem button onClick={() => toggleSection(section.key, section.title)} className={classes.drawerItem}>
                 <ListItemText primary={section.title} />
                 {expandedSections[section.key] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
               </ListItem>
@@ -190,7 +214,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
           ))}
           { linkSections.map((section) => (
             <React.Fragment key={section.key}>
-              <ListItem button onClick={() => toggleSection(section.key)} className={classes.drawerItem}>
+              <ListItem button onClick={() => toggleSection(section.key, section.title)} className={classes.drawerItem}>
                 <ListItemText primary={section.title} />
                 {expandedSections[section.key] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
               </ListItem>
@@ -201,6 +225,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
                       <ChplLink
                         href={item.href}
                         text={item.text}
+                        analytics={getItemAnalytics(item)}
                         external={false}
                         router={item.router}
                       />

--- a/src/app/navigation/mobile-nav-drawer.jsx
+++ b/src/app/navigation/mobile-nav-drawer.jsx
@@ -109,7 +109,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   const handleHomeClick = () => {
     eventTrack({
       ...analytics,
-      event: 'Go to Home Page',
+      event: 'Navigate to Home Page',
       label: 'Home',
       category: 'Navigation',
     });
@@ -120,7 +120,7 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   const handleSearchClick = () => {
     eventTrack({
       ...analytics,
-      event: 'Go to Search Page',
+      event: 'Navigate to Search Page',
       label: 'Search CHPL',
       category: 'Navigation',
     });

--- a/src/app/navigation/mobile-nav-drawer.jsx
+++ b/src/app/navigation/mobile-nav-drawer.jsx
@@ -133,7 +133,6 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
     eventTrack({
       ...analytics,
       event: isCurrentlyOpen ? `Collapse ${title}` : `Expand ${title}`,
-      label: title,
       category: 'Navigation',
     });
     setExpandedSections((previous) => ({

--- a/src/app/navigation/mobile-nav-drawer.jsx
+++ b/src/app/navigation/mobile-nav-drawer.jsx
@@ -107,23 +107,11 @@ function ChplMobileNavDrawer({ onHomeClick, onSearchClick }) {
   };
 
   const handleHomeClick = () => {
-    eventTrack({
-      ...analytics,
-      event: 'Navigate to Home Page',
-      label: 'Home',
-      category: 'Navigation',
-    });
     onHomeClick();
     closeMobileMenu();
   };
 
   const handleSearchClick = () => {
-    eventTrack({
-      ...analytics,
-      event: 'Navigate to Search Page',
-      label: 'Search CHPL',
-      category: 'Navigation',
-    });
     onSearchClick();
     closeMobileMenu();
   };

--- a/src/app/navigation/navigation-top.jsx
+++ b/src/app/navigation/navigation-top.jsx
@@ -16,7 +16,8 @@ import ChplMobileNavDrawer from './mobile-nav-drawer';
 import ChplAnnouncementsFab from 'components/announcements/announcements-fab';
 import ChplToggle from 'components/login/toggle';
 import { getAngularService } from 'services/angular-react-helper';
-import { FlagContext } from 'shared/contexts';
+import { eventTrack } from 'services/analytics.service';
+import { FlagContext, useAnalyticsContext } from 'shared/contexts';
 import { palette, theme } from 'themes';
 
 const useStyles = makeStyles({
@@ -106,10 +107,16 @@ function ChplNavigationTop() {
   const $location = getAngularService('$location');
   const $rootScope = getAngularService('$rootScope');
   const $state = getAngularService('$state');
+  const { analytics } = useAnalyticsContext();
   const { isProduction } = useContext(FlagContext);
   const classes = useStyles();
 
   const home = () => {
+    eventTrack({
+      ...analytics,
+      event: 'Go to Home Page',
+      category: 'Navigation',
+    });
     $rootScope.$broadcast('ClearResults', {});
     $localStorage.clearResults = true;
     sessionStorage.removeItem('storageKey-listingsPage-hasSearched');
@@ -121,6 +128,11 @@ function ChplNavigationTop() {
   };
 
   const searchChpl = () => {
+    eventTrack({
+      ...analytics,
+      event: 'Go to Search Page',
+      category: 'Navigation',
+    });
     $state.go('search');
   };
 


### PR DESCRIPTION

This pull request adds analytics event tracking to the navigation components, allowing user interactions such as menu item clicks, section expansions/collapses, and navigation actions to be logged for analytics purposes. The changes are focused on enhancing the tracking of user behavior in both the admin and mobile navigation menus.

**Analytics event tracking enhancements:**

* Added `eventTrack` calls to the `ChplAdminMenuLinkItem` and `ChplAdminMenuSection` components to track clicks on admin menu links and the expanding/collapsing of admin menu sections. (`src/app/components/login/navigation/admin-menu-link-item.jsx` [[1]](diffhunk://#diff-c86a4acf2867a4eeca4855ffe2e0b1784c0a5636a2b60fdd3398c6a38b1f47b0R14-R15) [[2]](diffhunk://#diff-c86a4acf2867a4eeca4855ffe2e0b1784c0a5636a2b60fdd3398c6a38b1f47b0R40-R52); `src/app/components/login/navigation/admin-menu-section.jsx` [[3]](diffhunk://#diff-e00414f590471b6e2fc58b254cf6b169e1df81ee421fe48eadae83762773cd64R19-R20) [[4]](diffhunk://#diff-e00414f590471b6e2fc58b254cf6b169e1df81ee421fe48eadae83762773cd64R55-R70) [[5]](diffhunk://#diff-e00414f590471b6e2fc58b254cf6b169e1df81ee421fe48eadae83762773cd64L67-R79)
* Integrated analytics tracking into the mobile navigation drawer for home and search button clicks, as well as expanding/collapsing widget and link sections. (`src/app/navigation/mobile-nav-drawer.jsx` [[1]](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844L29-R30) [[2]](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844R92) [[3]](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844R110-R147) [[4]](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844L179-R203) [[5]](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844L193-R217)
* Provided a utility to attach analytics event data to navigation items, enabling consistent event logging for link clicks in the mobile navigation. (`src/app/navigation/mobile-nav-drawer.jsx` [src/app/navigation/mobile-nav-drawer.jsxR228](diffhunk://#diff-1831078f0cfdcf94d3814b27edbbe9a45c2dd71e5efe9d4bdfd63d44b3191844R228))